### PR TITLE
Update CleanStart All Images link to image-specific URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ docker pull --platform linux/arm64 ghcr.io/cleanstart-containers/openldap:latest
 - **OpenLDAP Documentation:** https://www.openldap.org/
 - **Provenance / SBOM / Signature:** https://images.cleanstart.com/images/openldap
 - **Docker Hub:** https://hub.docker.com/r/cleanstart/openldap
-- **CleanStart All Images:** https://images.cleanstart.com
+- **CleanStart All Images:** https://images.cleanstart.com/images/openldap/details
 - **CleanStart Community Images:** https://hub.docker.com/u/cleanstart
 
 ---


### PR DESCRIPTION
## Summary
Replaces the generic **CleanStart All Images** link with the image-specific details URL.

**Before:** `CleanStart All Images: https://images.cleanstart.com`  
**After:** `CleanStart All Images: https://images.cleanstart.com/images/openldap/details`

---
*Auto-generated by update_cleanstart_all_images_link.py*
